### PR TITLE
Add skill tree and timeline to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,69 @@
     <title>莊冠霖的網站</title>
     <script type="module" crossorigin src="/eric_site/assets/index-fTJvJ01Y.js"></script>
     <link rel="stylesheet" crossorigin href="/eric_site/assets/index-Cf2kOY1E.css">
+    <style>
+      body { font-family: sans-serif; line-height: 1.5; }
+      section { max-width: 800px; margin: 2rem auto; }
+      h2 { margin-top: 2rem; }
+      ul, ol { padding-left: 1.5rem; }
+      #timeline li { margin-bottom: 0.5rem; }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"></div>
+
+    <section id="skills">
+      <h2>技能樹</h2>
+      <h3>程式語言</h3>
+      <ul>
+        <li>C/C++</li>
+        <li>Python</li>
+        <li>PHP（基本語法）</li>
+        <li>SQL（基本語法）</li>
+      </ul>
+      <h3>作業系統</h3>
+      <ul>
+        <li>Windows</li>
+        <li>Linux
+          <ul>
+            <li>RedHat</li>
+            <li>Kali</li>
+          </ul>
+        </li>
+      </ul>
+    </section>
+
+    <section id="timeline">
+      <h2>Timeline</h2>
+      <ul>
+        <li>NCPC 參加決賽</li>
+        <li>ICPC 參加初賽</li>
+        <li>AIS3 EOF 參加初賽</li>
+        <li>AIS3 Club 參加</li>
+        <li>台東大學資安研究社副社長&課程講師</li>
+        <li>picoCTF 線上賽 參加</li>
+        <li>Cpe 最高排名 2.3%</li>
+        <li>擔任演算法和資料結構助教</li>
+        <li>勤業眾信 Cyber Detect and Response 2023-2024</li>
+        <li>2023 TANET & NCS 臺灣網際網路研討會暨全國計算機會議，王忍成，莊冠霖，陳奕翔，黃致瑜，陳建智，「具意圖導向之人工智慧輔助文案生成方法建構－以台灣兩大黨政治文案為例」</li>
+      </ul>
+    </section>
+
+    <section id="projects">
+      <h2>作品集 (GitHub)</h2>
+      <ol>
+        <li>ATT&CK APT29（模擬攻擊）</li>
+        <li>研究 AI 攻擊手法以及工具整合（主要 adversarial-robustness-toolbox）</li>
+        <li>Python 寫一個 RAT 程式</li>
+        <li>與教授合作系上面試網站（PHP）</li>
+        <li>架設 Linux 各種 server</li>
+        <li>自己的 Blog（PHP）</li>
+        <li>蝦皮自動簽到</li>
+        <li>PTT 新聞爬蟲結合 Discord 機器人</li>
+        <li>Google 關鍵字 TF-IDF 分析</li>
+      </ol>
+      <p>#Python #PHP #AI #C++ #MySQL #Vmware #Shell #Linux</p>
+    </section>
   </body>
+</html>
 </html>


### PR DESCRIPTION
## Summary
- Add inline styles and new sections to `index.html` for a skills tree, timeline, and project list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689559d254ac8329b49012c637b56478