### PR TITLE
feat: extract reusable navbar component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,22 @@
 // src/App.tsx
-import { Routes, Route, Link } from "react-router-dom";
-import ProjectPage from "./pages/Home"; // 你的 GitHub 頁
+import { Routes, Route } from "react-router-dom";
+import Navbar from "./components/Navbar";
+import ProjectsPage from "./pages/Projects"; // 你的 GitHub 頁
 import IndexPage from "./pages/Index"; // 新增首頁頁面
 
 function App() {
+  const navItems = [
+    { label: "首頁", to: "/" },
+    { label: "GitHub 專案", to: "/projects" },
+  ];
+
   return (
     <>
-      <nav className="bg-gray-900 text-white p-4 flex gap-4">
-        <Link to="/" className="hover:underline">首頁</Link>
-        <Link to="/projects" className="hover:underline">GitHub 專案</Link>
-      </nav>
+      <Navbar items={navItems} />
 
       <Routes>
         <Route path="/" element={<IndexPage />} />
-        <Route path="/projects" element={<ProjectPage />} />
+        <Route path="/projects" element={<ProjectsPage />} />
       </Routes>
     </>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+
+// Item can be either a router link (to) or an anchor link (href)
+export type NavItem =
+  | { label: string; to: string }
+  | { label: string; href: string };
+
+interface NavbarProps {
+  items: NavItem[];
+  className?: string;
+}
+
+export default function Navbar({ items, className }: NavbarProps) {
+  const navClass = className ?? "bg-gray-900 text-white p-4 flex gap-4";
+
+  return (
+    <nav className={navClass}>
+      {items.map((item, idx) =>
+        "to" in item ? (
+          <Link key={idx} to={item.to} className="hover:underline">
+            {item.label}
+          </Link>
+        ) : (
+          <a key={idx} href={item.href} className="hover:underline">
+            {item.label}
+          </a>
+        )
+      )}
+    </nav>
+  );
+}

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-
+import Navbar from "../components/Navbar";
 
 // 定義 Repo 的型別
 interface Repo {
@@ -12,7 +12,7 @@ interface Repo {
   fork: boolean;
 }
 
-export default function Home() {
+export default function Projects() {
   const [repos, setRepos] = useState<Repo[]>([]);
 
   useEffect(() => {
@@ -35,20 +35,15 @@ export default function Home() {
       <header className="py-12 text-center">
         <h1 className="text-5xl font-extrabold mb-2 drop-shadow-lg">莊冠霖</h1>
         <p className="text-lg">資安筆記、GitHub 專案展示</p>
-        <nav className="mt-4 space-x-6 text-sm">
-          <a href="#" className="hover:underline">
-            HOME
-          </a>
-          <a href="#" className="hover:underline">
-            BLOG
-          </a>
-          <a href="#" className="hover:underline">
-            PROJECTS
-          </a>
-          <a href="#" className="hover:underline">
-            CONTACT
-          </a>
-        </nav>
+        <Navbar
+          items={[
+            { label: "HOME", href: "#" },
+            { label: "BLOG", href: "#" },
+            { label: "PROJECTS", href: "#" },
+            { label: "CONTACT", href: "#" },
+          ]}
+          className="mt-4 space-x-6 text-sm"
+        />
       </header>
 
       {/* Projects 區 */}


### PR DESCRIPTION
## Summary
- create reusable `Navbar` component
- replace hardcoded navs in `App` and `Projects` pages with `<Navbar />`
- allow nav styling customization through props

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899811463f883299e29f839f4b59b28