### PR TITLE
Add skill tree, timeline, and multi-page navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,25 @@
 // src/App.tsx
 import { Routes, Route, Link } from "react-router-dom";
-import ProjectPage from "./pages/Home"; // 你的 GitHub 頁
-import IndexPage from "./pages/Index"; // 新增首頁頁面
+import ProjectsPage from "./pages/Projects"; // GitHub 專案頁面
+import IndexPage from "./pages/Index"; // 首頁
+import BlogPage from "./pages/Blog";
+import ContactPage from "./pages/Contact";
 
 function App() {
   return (
     <>
       <nav className="bg-gray-900 text-white p-4 flex gap-4">
-        <Link to="/" className="hover:underline">首頁</Link>
-        <Link to="/projects" className="hover:underline">GitHub 專案</Link>
+        <Link to="/" className="hover:underline">HOME</Link>
+        <Link to="/blog" className="hover:underline">BLOG</Link>
+        <Link to="/projects" className="hover:underline">PROJECTS</Link>
+        <Link to="/contact" className="hover:underline">CONTACT</Link>
       </nav>
 
       <Routes>
         <Route path="/" element={<IndexPage />} />
-        <Route path="/projects" element={<ProjectPage />} />
+        <Route path="/blog" element={<BlogPage />} />
+        <Route path="/projects" element={<ProjectsPage />} />
+        <Route path="/contact" element={<ContactPage />} />
       </Routes>
     </>
   );

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+export default function SkillTree() {
+  const tags = [
+    "Python",
+    "PHP",
+    "AI",
+    "C++",
+    "MySQL",
+    "Vmware",
+    "Shell",
+    "Linux",
+  ];
+
+  return (
+    <section className="bg-slate-900/60 backdrop-blur-md rounded-xl p-8 shadow-lg">
+      <h2 className="text-3xl font-bold mb-6 text-center">🛠️ Skill Tree</h2>
+      <ul className="space-y-4">
+        <li>
+          <span className="font-semibold">Programming Languages</span>
+          <ul className="ml-6 list-disc space-y-1">
+            <li>C/C++</li>
+            <li>Python</li>
+            <li>PHP (basic)</li>
+            <li>SQL (basic)</li>
+          </ul>
+        </li>
+        <li>
+          <span className="font-semibold">Operating Systems</span>
+          <ul className="ml-6 list-disc space-y-1">
+            <li>Windows</li>
+            <li>
+              Linux
+              <ul className="ml-6 list-disc space-y-1">
+                <li>RedHat</li>
+                <li>Kali</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <span className="font-semibold">Tools & Others</span>
+          <ul className="ml-6 list-disc space-y-1">
+            <li>MySQL</li>
+            <li>Vmware</li>
+            <li>Shell</li>
+            <li>AI</li>
+          </ul>
+        </li>
+      </ul>
+      <div className="mt-6 flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="bg-indigo-600 text-white px-3 py-1 rounded-full text-sm"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface TimelineItem {
+  date: string;
+  content: string;
+}
+
+const items: TimelineItem[] = [
+  { date: "", content: "NCPC 參加決賽" },
+  { date: "", content: "ICPC 參加初賽" },
+  { date: "", content: "AIS3 EOF 參加初賽" },
+  { date: "", content: "AIS3 Club 參加" },
+  { date: "", content: "台東大學資安研究社副社長 && 課程講師" },
+  { date: "", content: "picoCTF 線上賽 參加" },
+  { date: "", content: "CPE 最高排名 2.3%" },
+  { date: "", content: "擔任演算法和資料結構助教" },
+  { date: "2023-2024", content: "勤業眾信 Cyber Detect and Response" },
+  {
+    date: "2023",
+    content:
+      "TANET & NCS 台灣網際網路研討會暨全國計算機會議 發表論文：具意圖導向之人工智慧輔助文案生成方法建構－以台灣兩大黨政治文案為例",
+  },
+];
+
+export default function Timeline() {
+  return (
+    <section className="bg-slate-900/60 backdrop-blur-md rounded-xl p-8 shadow-lg">
+      <h2 className="text-3xl font-bold mb-6 text-center">📅 Timeline</h2>
+      <ol className="relative border-l border-gray-700">
+        {items.map((item, idx) => (
+          <li key={idx} className="mb-10 ml-6">
+            <span className="absolute -left-3 flex items-center justify-center w-3 h-3 bg-cyan-400 rounded-full mt-1.5" />
+            {item.date && (
+              <time className="mb-1 text-sm text-gray-400">{item.date}</time>
+            )}
+            <p className="text-lg leading-relaxed">{item.content}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,0 +1,13 @@
+import Footer from '../components/Footer';
+
+export default function Blog() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white px-6 py-16">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-4xl font-extrabold mb-4 text-center">Blog</h1>
+        <p className="text-center">📝 Blog posts will be published here soon. Stay tuned!</p>
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,21 @@
+import Footer from '../components/Footer';
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white px-6 py-16">
+      <div className="max-w-xl mx-auto space-y-6">
+        <h1 className="text-4xl font-extrabold mb-4 text-center">Contact</h1>
+        <p className="text-center">Feel free to reach out through any of the platforms below.</p>
+        <ul className="space-y-2 text-center">
+          <li>
+            Email: <a href="mailto:goole910805@gmail.com" className="underline hover:text-cyan-400">goole910805@gmail.com</a>
+          </li>
+          <li>
+            GitHub: <a href="https://github.com/and910805" target="_blank" rel="noopener noreferrer" className="underline hover:text-cyan-400">and910805</a>
+          </li>
+        </ul>
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,7 @@
 import cehCertImg from '../assets/ceh-cert.png';
 import Footer from '../components/Footer';
+import SkillTree from '../components/SkillTree';
+import Timeline from '../components/Timeline';
 
 export default function Index() {
   return (
@@ -30,6 +32,11 @@ export default function Index() {
             </ul>
           </div>
         </section>
+        {/* 技能樹 */}
+        <SkillTree />
+
+        {/* 時間軸 */}
+        <Timeline />
 
         {/* 證照區塊 */}
         <section className="flex flex-col md:flex-row items-center gap-8 bg-slate-900/60 backdrop-blur-md rounded-xl p-8 shadow-lg">

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 
 // 定義 Repo 的型別
@@ -12,7 +13,7 @@ interface Repo {
   fork: boolean;
 }
 
-export default function Home() {
+export default function Projects() {
   const [repos, setRepos] = useState<Repo[]>([]);
 
   useEffect(() => {
@@ -36,18 +37,18 @@ export default function Home() {
         <h1 className="text-5xl font-extrabold mb-2 drop-shadow-lg">莊冠霖</h1>
         <p className="text-lg">資安筆記、GitHub 專案展示</p>
         <nav className="mt-4 space-x-6 text-sm">
-          <a href="#" className="hover:underline">
+          <Link to="/" className="hover:underline">
             HOME
-          </a>
-          <a href="#" className="hover:underline">
+          </Link>
+          <Link to="/blog" className="hover:underline">
             BLOG
-          </a>
-          <a href="#" className="hover:underline">
+          </Link>
+          <Link to="/projects" className="hover:underline">
             PROJECTS
-          </a>
-          <a href="#" className="hover:underline">
+          </Link>
+          <Link to="/contact" className="hover:underline">
             CONTACT
-          </a>
+          </Link>
         </nav>
       </header>
 


### PR DESCRIPTION
## Summary
- Add SkillTree and Timeline components and integrate into home page
- Add navigation header linking Home, Blog, Projects, and Contact pages
- Implement Projects page displaying GitHub repos and placeholder Blog/Contact pages

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_6895bde252d88329b624e14ef9521eb5