### PR TITLE
Add contact form page with validation and submission

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import { Routes, Route, Link } from "react-router-dom";
 import ProjectPage from "./pages/Home"; // 你的 GitHub 頁
 import IndexPage from "./pages/Index"; // 新增首頁頁面
+import ContactPage from "./pages/Contact";
 
 function App() {
   return (
@@ -9,11 +10,13 @@ function App() {
       <nav className="bg-gray-900 text-white p-4 flex gap-4">
         <Link to="/" className="hover:underline">首頁</Link>
         <Link to="/projects" className="hover:underline">GitHub 專案</Link>
+        <Link to="/contact" className="hover:underline">聯絡我</Link>
       </nav>
 
       <Routes>
         <Route path="/" element={<IndexPage />} />
         <Route path="/projects" element={<ProjectPage />} />
+        <Route path="/contact" element={<ContactPage />} />
       </Routes>
     </>
   );

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,115 @@
+import { useState, type ChangeEvent, type FormEvent } from "react";
+
+interface FormData {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export default function Contact() {
+  const [form, setForm] = useState<FormData>({ name: "", email: "", message: "" });
+  const [status, setStatus] = useState<"idle" | "success" | "error" | "loading">("idle");
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const validateEmail = (email: string) => /[^@\s]+@[^@\s]+\.[^@\s]+/.test(email);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!form.name || !validateEmail(form.email) || !form.message) {
+      setStatus("error");
+      return;
+    }
+    try {
+      setStatus("loading");
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error("Network response was not ok");
+      setStatus("success");
+      setForm({ name: "", email: "", message: "" });
+    } catch (err) {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-white px-6 py-16">
+      <div className="max-w-lg mx-auto">
+        <h1 className="text-3xl font-bold mb-6 text-center">Contact</h1>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 bg-slate-900/60 backdrop-blur-md p-6 rounded-xl shadow-lg"
+        >
+          <div>
+            <label htmlFor="name" className="block mb-1 font-semibold">
+              Name
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              value={form.name}
+              onChange={handleChange}
+              className="w-full p-2 rounded text-black"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="email" className="block mb-1 font-semibold">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              className="w-full p-2 rounded text-black"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="message" className="block mb-1 font-semibold">
+              Message
+            </label>
+            <textarea
+              id="message"
+              name="message"
+              value={form.message}
+              onChange={handleChange}
+              className="w-full p-2 rounded text-black"
+              rows={5}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={status === "loading"}
+            className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 transition disabled:opacity-50"
+          >
+            {status === "loading" ? "Sending..." : "Send"}
+          </button>
+        </form>
+        {status === "success" && (
+          <p className="text-green-400 mt-4 text-center">
+            Message sent successfully!
+          </p>
+        )}
+        {status === "error" && (
+          <p className="text-red-500 mt-4 text-center">
+            Something went wrong. Please check your inputs and try again.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add navigation and route for new contact page
- implement contact form with name, email, message fields and fetch-based submission
- show success or error message after form submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689980f0c8cc8329ba3419fa97d0b1b8